### PR TITLE
增大writeBufferSize大小，减少读取和写入的循环次数，提高writeToBIO速度

### DIFF
--- a/app/src/main/java/com/obs/services/internal/RepeatableRequestEntity.java
+++ b/app/src/main/java/com/obs/services/internal/RepeatableRequestEntity.java
@@ -39,7 +39,7 @@ public class RepeatableRequestEntity extends RequestBody implements Closeable {
 	private volatile long bytesWritten = 0;
 	private InputStream inputStream;
 
-	private static final int writeBufferSize = ObsConstraint.DEFAULT_CHUNK_SIZE;
+	private static final int writeBufferSize = ObsConstraint.DEFAULT_BUFFER_STREAM;
 
 	public RepeatableRequestEntity(InputStream is, String contentType, long contentLength,
 			ObsProperties obsProperties) {


### PR DESCRIPTION
我使用的贵方的esdk-obs-java，版本为3.23.9。使用过程中发现超过50M的文件上传就需要20-50s不等。经过排查发现是com.obs.services.internal.RepeatableRequestEntity 中的writeToBIO(BufferedSink out)方法执行时间过长导致的整体速度慢。为提高整体响应时间，我对writeBufferSize的大小进行了调整，望审批。