### PR TITLE
Version 3.24.8

### DIFF
--- a/README-Android.md
+++ b/README-Android.md
@@ -1,3 +1,21 @@
+Version 3.24.8
+Resolved issues:
+1. PutObject、Getobject、GetObjectMetadata、UploadPart、AppendObject、CopyObject、CopyPart、CompeleMultiUploadPart now supports crc64 checksum.
+2. UploadFile can be cancelled and aborted now.
+3. Allow you set okhttp's EventListenerFactory to profile each stage of a http request，not set by default.
+4. Fixed the issue that client encryption is available only in obs protocal and add some check logic when encryption algrithm is null.
+5. Optimised the logic of set progress listener when using uploadFile.
+6. Optimised some log info format.
+7. Added some logic to compatible with Android 7.0 when using DateTimeFormatter. 
+
+Third-party dependence:
+1. Replace okio 3.8.0 with okio 3.6.0 
+2. Replace log4j-core 2.20.0 with log4j-core 2.18.0 
+3. Replace jackson-core 2.15.4 with jackson-core 2.15.2 
+4. Replace jackson-databind 2.15.4 with jackson-databind 2.15.2 
+5. Replace jackson-annotations 2.15.4 with jackson-annotations 2.15.2
+6. Replace log4j-api 2.20.0 with log4j-api 2.18.0 
+-----------------------------------------------------------------------------------
 Version 3.24.3
 Resolved issues:
 1. Optimized log info of some exception stack

--- a/README-Java.md
+++ b/README-Java.md
@@ -1,3 +1,21 @@
+Version 3.24.8
+Resolved issues:
+1. PutObject、Getobject、GetObjectMetadata、UploadPart、AppendObject、CopyObject、CopyPart、CompeleMultiUploadPart now supports crc64 checksum.
+2. UploadFile can be cancelled and aborted now.
+3. Allow you set okhttp's EventListenerFactory to profile each stage of a http request，not set by default.
+4. Fixed the issue that client encryption is available only in obs protocal and add some check logic when encryption algrithm is null.
+5. Optimised the logic of set progress listener when using uploadFile.
+6. Optimised some log info format.
+7. Added some logic to compatible with Android 7.0 when using DateTimeFormatter. 
+
+Third-party dependence:
+1. Replace okio 3.8.0 with okio 3.6.0 
+2. Replace log4j-core 2.20.0 with log4j-core 2.18.0 
+3. Replace jackson-core 2.15.4 with jackson-core 2.15.2 
+4. Replace jackson-databind 2.15.4 with jackson-databind 2.15.2 
+5. Replace jackson-annotations 2.15.4 with jackson-annotations 2.15.2
+6. Replace log4j-api 2.20.0 with log4j-api 2.18.0 
+-----------------------------------------------------------------------------------
 Version 3.24.3
 Resolved issues:
 1. Optimized log info of some exception stack

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,21 @@
+Version 3.24.8
+Resolved issues:
+1. PutObject、Getobject、GetObjectMetadata、UploadPart、AppendObject、CopyObject、CopyPart、CompeleMultiUploadPart now supports crc64 checksum.
+2. UploadFile can be cancelled and aborted now.
+3. Allow you set okhttp's EventListenerFactory to profile each stage of a http request，not set by default.
+4. Fixed the issue that client encryption is available only in obs protocal and add some check logic when encryption algrithm is null.
+5. Optimised the logic of set progress listener when using uploadFile.
+6. Optimised some log info format.
+7. Added some logic to compatible with Android 7.0 when using DateTimeFormatter. 
+
+Third-party dependence:
+1. Replace okio 3.8.0 with okio 3.6.0 
+2. Replace log4j-core 2.20.0 with log4j-core 2.18.0 
+3. Replace jackson-core 2.15.4 with jackson-core 2.15.2 
+4. Replace jackson-databind 2.15.4 with jackson-databind 2.15.2 
+5. Replace jackson-annotations 2.15.4 with jackson-annotations 2.15.2
+6. Replace log4j-api 2.20.0 with log4j-api 2.18.0 
+-----------------------------------------------------------------------------------
 Version 3.24.3
 Resolved issues:
 1. Optimized log info of some exception stack

--- a/README_CN.MD
+++ b/README_CN.MD
@@ -1,3 +1,21 @@
+Version 3.24.8
+Resolved issues:
+1. PutObject、Getobject、GetObjectMetadata、UploadPart、AppendObject、CopyObject、CopyPart、CompeleMultiUploadPart支持crc64校验
+2. 断点续传上传支持暂停、取消
+3. 支持设置okhttp的EventListenerFactory，用于统计http请求各阶段耗时，默认关闭
+4. 修复客户端加密只能在obs协议下使用的问题，增加加密算法为null时的判断
+5. 优化断点续传上传时的进度条设置逻辑
+6. 优化部分日志打印格式
+7. 使用DateTimeFormatter时兼容Android 7.0
+
+Third-party dependence:
+1. 使用 okio 3.8.0 替代 okio 3.6.0 
+2. 使用 log4j-core 2.20.0 替代 log4j-core 2.18.0 
+3. 使用 jackson-core 2.15.4 替代 jackson-core 2.15.2 
+4. 使用 jackson-databind 2.15.4 替代 jackson-databind 2.15.2 
+5. 使用 jackson-annotations 2.15.4 替代 jackson-annotations 2.15.2
+6. 使用 log4j-api 2.20.0 替代 log4j-api 2.18.0 
+-----------------------------------------------------------------------------------
 Version 3.24.3
 Resolved issues:
 1. 优化某些堆栈的日志打印

--- a/app/src/main/java/com/obs/log/LoggerBuilder.java
+++ b/app/src/main/java/com/obs/log/LoggerBuilder.java
@@ -39,8 +39,8 @@ public class LoggerBuilder {
                     try {
                         loggerClass = Class.forName("java.util.logging.Logger");
                         getLoggerClass = GetLoggerHolder.loggerClass.getMethod("getLogger", String.class);
-                    } catch (NoSuchMethodException | SecurityException | ClassNotFoundException |
-                             NoClassDefFoundError exx) {
+                    } catch (NoSuchMethodException | SecurityException | ClassNotFoundException
+                            | NoClassDefFoundError exx) {
                         ILOG.warning(exx.getMessage());
                     }
                 }

--- a/app/src/main/java/com/obs/services/AbstractClient.java
+++ b/app/src/main/java/com/obs/services/AbstractClient.java
@@ -68,7 +68,8 @@ public abstract class AbstractClient extends ObsService implements Closeable, IO
         if (this.isAuthTypeNegotiation()) {
             this.getProviderCredentials().setIsAuthTypeNegotiation(true);
         }
-        this.initHttpClient(config.getHttpDispatcher(), config.getCustomizedDnsImpl(), config.getHostnameVerifier());
+        this.initHttpClient(config.getHttpDispatcher(), config.getCustomizedDnsImpl(), config.getHostnameVerifier(),
+                config.getEventListenerFactory());
         OBSXMLBuilder.setXmlDocumentBuilderFactoryClass(config.getXmlDocumentBuilderFactoryClass());
         reqBean.setRespTime(new Date());
         reqBean.setResultCode(Constants.RESULTCODE_SUCCESS);

--- a/app/src/main/java/com/obs/services/IObsClientAsync.java
+++ b/app/src/main/java/com/obs/services/IObsClientAsync.java
@@ -1,0 +1,12 @@
+package com.obs.services;
+
+import com.obs.services.internal.task.UploadFileTask;
+import com.obs.services.model.CompleteMultipartUploadResult;
+import com.obs.services.model.TaskCallback;
+import com.obs.services.model.UploadFileRequest;
+
+public interface IObsClientAsync {
+    UploadFileTask uploadFileAsync(
+            UploadFileRequest uploadFileRequest,
+            TaskCallback<CompleteMultipartUploadResult, UploadFileRequest> completeCallback);
+}

--- a/app/src/main/java/com/obs/services/ObsClientAsync.java
+++ b/app/src/main/java/com/obs/services/ObsClientAsync.java
@@ -1,0 +1,159 @@
+package com.obs.services;
+
+import com.obs.log.ILogger;
+import com.obs.log.LoggerBuilder;
+import com.obs.services.internal.task.UploadFileTask;
+import com.obs.services.model.CompleteMultipartUploadResult;
+import com.obs.services.model.TaskCallback;
+import com.obs.services.model.UploadFileRequest;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class ObsClientAsync extends ObsClient implements IObsClientAsync {
+    /**
+     * Constructor
+     *
+     * @param endPoint OBS endpoint
+     */
+    public ObsClientAsync(String endPoint) {
+        super(endPoint);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param config Configuration parameters of ObsClient
+     */
+    public ObsClientAsync(ObsConfiguration config) {
+        super(config);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param accessKey AK in the access key
+     * @param secretKey SK in the access key
+     * @param endPoint  OBS endpoint
+     */
+    public ObsClientAsync(String accessKey, String secretKey, String endPoint) {
+        super(accessKey, secretKey, endPoint);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param accessKey AK in the access key
+     * @param secretKey SK in the access key
+     * @param config    Configuration parameters of ObsClient
+     */
+    public ObsClientAsync(String accessKey, String secretKey, ObsConfiguration config) {
+        super(accessKey, secretKey, config);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param accessKey     AK in the temporary access key
+     * @param secretKey     SK in the temporary access key
+     * @param securityToken Security token
+     * @param endPoint      OBS endpoint
+     */
+    public ObsClientAsync(String accessKey, String secretKey, String securityToken, String endPoint) {
+        super(accessKey, secretKey, securityToken, endPoint);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param accessKey     AK in the temporary access key
+     * @param secretKey     SK in the temporary access key
+     * @param securityToken Security token
+     * @param config        Configuration parameters of ObsClient
+     */
+    public ObsClientAsync(String accessKey, String secretKey, String securityToken, ObsConfiguration config) {
+        super(accessKey, secretKey, securityToken, config);
+    }
+
+    public ObsClientAsync(IObsCredentialsProvider provider, String endPoint) {
+        super(provider, endPoint);
+    }
+
+    public ObsClientAsync(IObsCredentialsProvider provider, ObsConfiguration config) {
+        super(provider, config);
+    }
+
+    private static final ILogger log = LoggerBuilder.getLogger(ObsClientAsync.class);
+    private ExecutorService asyncClientExecutorService;
+    private static final int DEFAULT_CLIENT_EXECUTOR_SERVICE_SIZE = 128;
+
+    private int queryInterval = 1000;
+
+    @Override
+    public void close() throws IOException {
+        log.warn("ObsClientAsync closing");
+        try {
+            // finishing all task
+            getExecutorService().shutdown();
+            log.warn("ObsClientAsync closed");
+        } catch (Exception e) {
+            log.warn("ObsClientAsync close failed, detail:", e);
+        }
+        super.close();
+    }
+
+    private static final String ASYNC_CLIENT_EXECUTOR_SERVICE_THREAD_NAME = "async-client-thread";
+    protected ExecutorService getExecutorService() {
+        if (asyncClientExecutorService == null) {
+            asyncClientExecutorService = Executors.newFixedThreadPool(DEFAULT_CLIENT_EXECUTOR_SERVICE_SIZE,
+                    r -> new Thread(r, ASYNC_CLIENT_EXECUTOR_SERVICE_THREAD_NAME));
+        }
+        return asyncClientExecutorService;
+    }
+
+    public void setExecutorService(ExecutorService service) {
+        if (asyncClientExecutorService != null) { // wait for all task finish
+            asyncClientExecutorService.shutdown();
+            while (!asyncClientExecutorService.isTerminated()) {
+                try {
+                    Thread.sleep(queryInterval);
+                } catch (InterruptedException e) {
+                    log.warn("ObsClientAsync setExecutorService failed, detail:", e);
+                }
+            }
+        }
+        asyncClientExecutorService = service;
+    }
+
+    public int getQueryInterval() {
+        return queryInterval;
+    }
+
+    public void setQueryInterval(int queryInterval) {
+        this.queryInterval = queryInterval;
+    }
+
+    /**
+     * @param uploadFileRequest
+     * @param completeCallback
+     * @return
+     */
+    @Override
+    public UploadFileTask uploadFileAsync(
+            UploadFileRequest uploadFileRequest,
+            TaskCallback<CompleteMultipartUploadResult, UploadFileRequest> completeCallback) {
+        log.debug("start uploadFileAsync");
+        if (uploadFileRequest.getCancelHandler() != null) {
+            uploadFileRequest.getCancelHandler().resetCancelStatus();
+        }
+        UploadFileTask uploadFileTask =
+                new UploadFileTask(this, uploadFileRequest.getBucketName(), uploadFileRequest, completeCallback);
+        Future<?> future = getExecutorService().submit((Callable<?>) uploadFileTask);
+
+        uploadFileTask.setResultFuture(future);
+        return uploadFileTask;
+    }
+}

--- a/app/src/main/java/com/obs/services/ObsConfiguration.java
+++ b/app/src/main/java/com/obs/services/ObsConfiguration.java
@@ -24,6 +24,7 @@ import com.obs.services.model.HttpProtocolTypeEnum;
 
 import okhttp3.Dispatcher;
 import okhttp3.Dns;
+import okhttp3.EventListener;
 
 import java.security.SecureRandom;
 
@@ -104,6 +105,7 @@ public class ObsConfiguration implements Cloneable {
     private HostnameVerifier hostnameVerifier;
     
     private String xmlDocumentBuilderFactoryClass;
+    private EventListener.Factory eventListenerFactory;
 
     /**
      * Constructor
@@ -939,4 +941,15 @@ public class ObsConfiguration implements Cloneable {
     public void setSecureRandom(SecureRandom secureRandom) {
         this.secureRandom = secureRandom;
     }
+
+    public EventListener.Factory getEventListenerFactory()
+    {
+        return eventListenerFactory;
+    }
+
+    public void setEventListenerFactory(EventListener.Factory eventListenerFactory)
+    {
+        this.eventListenerFactory = eventListenerFactory;
+    }
+
 }

--- a/app/src/main/java/com/obs/services/crypto/CryptoObsClient.java
+++ b/app/src/main/java/com/obs/services/crypto/CryptoObsClient.java
@@ -339,16 +339,20 @@ public class CryptoObsClient extends ObsClient {
         // 该接口是下载对象，需要将流返回给客户（调用方），我们不能关闭这个流
 
         if (ctrCipherGenerator != null) {
+            String headerMetaPrefix =
+                    this.getProviderCredentials() != null &&
+                            this.getProviderCredentials().getLocalAuthType(request.getBucketName()) != AuthTypeEnum.OBS
+                    ? Constants.V2_HEADER_META_PREFIX : Constants.OBS_HEADER_META_PREFIX;
             String encryptedAlgorithm =
                     (String)
                             objMetadata
                                     .getOriginalHeaders()
-                                    .get(Constants.OBS_HEADER_META_PREFIX + ENCRYPTED_ALGORITHM_META_NAME);
+                                    .get(headerMetaPrefix + ENCRYPTED_ALGORITHM_META_NAME);
             String encryptedStart =
                     (String)
                             objMetadata
                                     .getOriginalHeaders()
-                                    .get(Constants.OBS_HEADER_META_PREFIX + ENCRYPTED_START_META_NAME);
+                                    .get(headerMetaPrefix + ENCRYPTED_START_META_NAME);
 
             if (isValidEncryptedAlgorithm(encryptedAlgorithm)) {
                 byte[] cryptoKeyBytes = ctrCipherGenerator.getCryptoKeyBytes();
@@ -365,7 +369,7 @@ public class CryptoObsClient extends ObsClient {
                                             objMetadata
                                                     .getOriginalHeaders()
                                                     .get(
-                                                            Constants.OBS_HEADER_META_PREFIX
+                                                            headerMetaPrefix
                                                                     + ENCRYPTED_AES_KEY_META_NAME);
                             // 解密rsa加密后的主密钥
                             cryptoKeyBytes =
@@ -425,8 +429,8 @@ public class CryptoObsClient extends ObsClient {
     }
 
     public boolean isValidEncryptedAlgorithm(String encryptedAlgorithm) {
-        return encryptedAlgorithm.equals(CtrRSACipherGenerator.ENCRYPTED_ALGORITHM)
-                || encryptedAlgorithm.equals(CTRCipherGenerator.ENCRYPTED_ALGORITHM);
+        return encryptedAlgorithm != null && (encryptedAlgorithm.equals(CtrRSACipherGenerator.ENCRYPTED_ALGORITHM)
+                || encryptedAlgorithm.equals(CTRCipherGenerator.ENCRYPTED_ALGORITHM));
     }
 
     protected byte[] getOrGenerateCryptoIvBytes() {

--- a/app/src/main/java/com/obs/services/exception/ObsException.java
+++ b/app/src/main/java/com/obs/services/exception/ObsException.java
@@ -14,6 +14,7 @@
 
 package com.obs.services.exception;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,17 +65,32 @@ public class ObsException extends RuntimeException {
 
     @Override
     public String toString() {
-        String myString = super.toString();
+        StringBuilder myString = new StringBuilder(super.toString());
 
         if (responseCode != -1) {
-            myString += " -- ResponseCode: " + responseCode + ", ResponseStatus: " + responseStatus;
+            myString.append(" -- ResponseCode: ")
+                    .append(responseCode)
+                    .append(", ResponseStatus: ")
+                    .append(responseStatus);
         }
         if (isParsedFromXmlMessage()) {
-            myString += ", XML Error Message: " + xmlMessage;
+            myString.append(", XML Error Message: ").append(xmlMessage);
         } else if (errorRequestId != null) {
-            myString += ", RequestId: " + errorRequestId + ", HostId: " + errorHostId;
+            myString.append(", RequestId: ").append(errorRequestId).append(", HostId: ").append(errorHostId);
         }
-        return myString;
+        // 遍历Map的entry,打印所有报错相关头域
+        Map<String, String> headers = getResponseHeaders();
+        if (headers != null) {
+            for (Map.Entry<String, String> header : headers.entrySet()) {
+                if (header.getKey().toLowerCase(Locale.ROOT).contains("error")) {
+                    myString.append(", ErrorHeaderKey: ")
+                            .append(header.getKey())
+                            .append(", ErrorHeaderValue: ")
+                            .append(header.getValue());
+                }
+            }
+        }
+        return myString.toString();
     }
 
     private boolean isParsedFromXmlMessage() {

--- a/app/src/main/java/com/obs/services/internal/Constants.java
+++ b/app/src/main/java/com/obs/services/internal/Constants.java
@@ -60,7 +60,9 @@ public class Constants {
 
         public static final String CONTENT_DISPOSITION = "Content-Disposition";
 
-        public static final String HASH_CRC64ECMA = "hash-crc64ecma";
+        public static final String HASH_CRC64ECMA = "checksum-crc64ecma";
+
+        public static final String INVALID_CRC_64 = "InvalidCRC64";
 
         public static final String CONTENT_ENCODING = "Content-Encoding";
 
@@ -213,7 +215,7 @@ public class Constants {
 
     public static final TimeZone GMT_TIMEZONE = TimeZone.getTimeZone("GMT");
 
-    public static final String OBS_SDK_VERSION = "3.24.3";
+    public static final String OBS_SDK_VERSION = "3.24.8";
 
     public static final String USER_AGENT_VALUE = "obs-sdk-java/" + Constants.OBS_SDK_VERSION;
 

--- a/app/src/main/java/com/obs/services/internal/ProgressManager.java
+++ b/app/src/main/java/com/obs/services/internal/ProgressManager.java
@@ -31,6 +31,7 @@ public abstract class ProgressManager {
         }
     }
 
+    private boolean endFlag = true;
     protected final long totalBytes;
     protected long  startCheckpoint;
     protected long  lastCheckpoint;
@@ -78,4 +79,12 @@ public abstract class ProgressManager {
     public abstract void progressEnd();
 
     protected abstract void doProgressChanged(int bytes);
+
+    public boolean isEndFlag() {
+        return endFlag;
+    }
+
+    public void setEndFlag(boolean endFlag) {
+        this.endFlag = endFlag;
+    }
 }

--- a/app/src/main/java/com/obs/services/internal/RestConnectionService.java
+++ b/app/src/main/java/com/obs/services/internal/RestConnectionService.java
@@ -34,6 +34,7 @@ import com.obs.services.internal.utils.ServiceUtils;
 import com.obs.services.model.HttpMethodEnum;
 import okhttp3.Dispatcher;
 import okhttp3.Dns;
+import okhttp3.EventListener;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -57,10 +58,12 @@ public class RestConnectionService {
 
     protected volatile ProviderCredentials credentials;
 
-    protected void initHttpClient(Dispatcher httpDispatcher, Dns customizedDnsImpl, HostnameVerifier hostnameVerifier) {
+    protected void initHttpClient(Dispatcher httpDispatcher, Dns customizedDnsImpl, HostnameVerifier hostnameVerifier,
+            EventListener.Factory eventListenerFactory) {
 
         OkHttpClient.Builder builder = RestUtils.initHttpClientBuilder(obsProperties, keyManagerFactory,
-                trustManagerFactory, httpDispatcher, customizedDnsImpl, hostnameVerifier, credentials.getSecureRandom());
+                trustManagerFactory, httpDispatcher, customizedDnsImpl, eventListenerFactory, hostnameVerifier,
+                credentials.getSecureRandom());
 
         if (this.obsProperties.getBoolProperty(ObsConstraint.PROXY_ISABLE, true)) {
             String proxyHostAddress = this.obsProperties.getStringProperty(ObsConstraint.PROXY_HOST, null);

--- a/app/src/main/java/com/obs/services/internal/handler/XmlResponsesSaxParser.java
+++ b/app/src/main/java/com/obs/services/internal/handler/XmlResponsesSaxParser.java
@@ -982,6 +982,8 @@ public class XmlResponsesSaxParser {
     public static class CopyObjectResultHandler extends DefaultXmlHandler {
         private String etag;
 
+        private String crc64;
+
         private Date lastModified;
 
         public Date getLastModified() {
@@ -990,6 +992,10 @@ public class XmlResponsesSaxParser {
 
         public String getETag() {
             return etag;
+        }
+
+        public String getCRC64() {
+            return crc64;
         }
 
         @Override
@@ -1004,6 +1010,8 @@ public class XmlResponsesSaxParser {
                 }
             } else if (name.equals("ETag")) {
                 etag = elementText;
+            } else if (name.equals("CRC64")) {
+                crc64 = elementText;
             }
         }
     }
@@ -1646,12 +1654,14 @@ public class XmlResponsesSaxParser {
 
         private String etag;
 
+        private String crc64;
+
         public CopyPartResultHandler(XMLReader xr) {
             super(xr);
         }
 
         public CopyPartResult getCopyPartResult(int partNumber) {
-            CopyPartResult result = new CopyPartResult(partNumber, etag, lastModified);
+            CopyPartResult result = new CopyPartResult(partNumber, etag, lastModified, crc64);
             return result;
         }
 
@@ -1665,6 +1675,9 @@ public class XmlResponsesSaxParser {
 
         public void endETag(String content) {
             this.etag = content;
+        }
+        public void endCRC64(String content) {
+            this.crc64 = content;
         }
 
     }

--- a/app/src/main/java/com/obs/services/internal/io/ProgressInputStream.java
+++ b/app/src/main/java/com/obs/services/internal/io/ProgressInputStream.java
@@ -31,7 +31,7 @@ public class ProgressInputStream extends FilterInputStream {
     private boolean endFlag;
 
     public ProgressInputStream(InputStream in, ProgressManager progressManager) {
-        this(in, progressManager, true);
+        this(in, progressManager, progressManager.isEndFlag());
     }
 
     public ProgressInputStream(InputStream in, ProgressManager progressManager, boolean endFlag) {

--- a/app/src/main/java/com/obs/services/internal/service/AbstractRequestConvertor.java
+++ b/app/src/main/java/com/obs/services/internal/service/AbstractRequestConvertor.java
@@ -23,6 +23,7 @@ import com.obs.services.internal.ObsConstraint;
 import com.obs.services.internal.RestStorageService;
 import com.obs.services.internal.ServiceException;
 import com.obs.services.internal.trans.NewTransResult;
+import com.obs.services.internal.utils.CRC64;
 import com.obs.services.internal.utils.Mimetypes;
 import com.obs.services.internal.utils.ServiceUtils;
 import com.obs.services.model.AuthTypeEnum;
@@ -48,9 +49,9 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.Locale;
 
 public abstract class AbstractRequestConvertor extends RestStorageService {
     private static final ILogger log = LoggerBuilder.getLogger("com.obs.services.ObsClient");
@@ -64,6 +65,7 @@ public abstract class AbstractRequestConvertor extends RestStorageService {
         private Map<String, String> userHeaders = new HashMap<>();
 
         private RequestBody body;
+        private CRC64 calculatedCrc64;
 
         TransResult(Map<String, String> headers) {
             this(headers, null, null);
@@ -112,6 +114,15 @@ public abstract class AbstractRequestConvertor extends RestStorageService {
         public RequestBody getBody() {
             return body;
         }
+
+        public CRC64 getCalculatedCrc64() {
+            return calculatedCrc64;
+        }
+
+        public void setCalculatedCrc64(CRC64 calculatedCrc64) {
+            this.calculatedCrc64 = calculatedCrc64;
+        }
+
     }
 
     /**

--- a/app/src/main/java/com/obs/services/internal/service/ObsMultipartObjectService.java
+++ b/app/src/main/java/com/obs/services/internal/service/ObsMultipartObjectService.java
@@ -60,6 +60,7 @@ public abstract class ObsMultipartObjectService extends ObsObjectBaseService {
         this.prepareRESTHeaderAcl(request.getBucketName(), result.getHeaders(), request.getAcl());
 
         NewTransResult newTransResult = transObjectRequestWithResult(result, request);
+        newTransResult.setCancelHandler(request.getCancelHandler());
         Response response = performRequest(newTransResult, true, false, false, false);
 
         this.verifyResponseContentType(response);
@@ -107,6 +108,7 @@ public abstract class ObsMultipartObjectService extends ObsObjectBaseService {
         transResult.setParams(requestParams);
         transResult.setHeaders(headers);
         transResult.setBody(createRequestBody(Mimetypes.MIMETYPE_XML, xml));
+        transResult.setCancelHandler(request.getCancelHandler());
 
         Response response = performRequest(transResult, true, false, false, false);
 
@@ -240,6 +242,7 @@ public abstract class ObsMultipartObjectService extends ObsObjectBaseService {
         try {
             result = this.transUploadPartRequest(request);
             NewTransResult newTransResult = transObjectRequestWithResult(result, request);
+            newTransResult.setCancelHandler(request.getCancelHandler());
             response = performRequest(newTransResult);
         } finally {
             if (result != null && result.getBody() != null && request.isAutoClose()) {
@@ -248,9 +251,14 @@ public abstract class ObsMultipartObjectService extends ObsObjectBaseService {
             }
         }
         UploadPartResult ret = new UploadPartResult();
-        ret.setEtag(response.header(CommonHeaders.ETAG));
         ret.setPartNumber(request.getPartNumber());
-        setHeadersAndStatus(ret, response);
+        if (result != null) {
+            ret.setClientCalculatedCRC64(result.getCalculatedCrc64());
+        }
+        if (response != null) {
+            ret.setEtag(response.header(CommonHeaders.ETAG));
+            setHeadersAndStatus(ret, response);
+        }
         return ret;
     }
 

--- a/app/src/main/java/com/obs/services/internal/service/ObsObjectService.java
+++ b/app/src/main/java/com/obs/services/internal/service/ObsObjectService.java
@@ -153,6 +153,7 @@ public abstract class ObsObjectService extends ObsMultipartObjectService {
                 }
             }
         }
+        ret.setClientCalculatedCRC64(result.getCalculatedCrc64());
         return ret;
     }
     

--- a/app/src/main/java/com/obs/services/internal/task/AbstractTaskCallable.java
+++ b/app/src/main/java/com/obs/services/internal/task/AbstractTaskCallable.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2019 Huawei Technologies Co.,Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.obs.services.internal.task;
+
+import com.obs.services.AbstractClient;
+import com.obs.services.model.HeaderResponse;
+
+import java.util.concurrent.Callable;
+
+public abstract class AbstractTaskCallable<C extends HeaderResponse> implements Callable {
+    private AbstractClient obsClient;
+    private String bucketName;
+
+    public AbstractTaskCallable(AbstractClient obsClient, String bucketName) {
+        this.obsClient = obsClient;
+        this.bucketName = bucketName;
+    }
+
+    public AbstractClient getObsClient() {
+        return obsClient;
+    }
+
+    public void setObsClient(AbstractClient obsClient) {
+        this.obsClient = obsClient;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
+}

--- a/app/src/main/java/com/obs/services/internal/task/UploadFileTask.java
+++ b/app/src/main/java/com/obs/services/internal/task/UploadFileTask.java
@@ -1,0 +1,104 @@
+package com.obs.services.internal.task;
+
+import static com.obs.services.internal.utils.ServiceUtils.changeFromThrowable;
+
+import com.obs.log.ILogger;
+import com.obs.log.LoggerBuilder;
+import com.obs.services.AbstractClient;
+import com.obs.services.exception.ObsException;
+import com.obs.services.model.CompleteMultipartUploadResult;
+import com.obs.services.model.TaskCallback;
+import com.obs.services.model.UploadFileRequest;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class UploadFileTask extends AbstractTaskCallable<CompleteMultipartUploadResult> {
+    private UploadFileRequest taskRequest;
+    private TaskCallback<CompleteMultipartUploadResult, UploadFileRequest> completeCallback;
+
+    private Future<?> resultFuture;
+
+    private static final ILogger log = LoggerBuilder.getLogger(UploadFileTask.class);
+
+    public UploadFileTask(
+            AbstractClient obsClient,
+            String bucketName,
+            UploadFileRequest taskRequest,
+            TaskCallback<CompleteMultipartUploadResult, UploadFileRequest> completeCallback) {
+        super(obsClient, bucketName);
+        this.taskRequest = taskRequest;
+        this.completeCallback = completeCallback;
+    }
+
+    public Optional<CompleteMultipartUploadResult> getResult() {
+        try {
+            Object result = resultFuture.get();
+            if (result instanceof CompleteMultipartUploadResult) {
+                return Optional.of((CompleteMultipartUploadResult) result);
+            } else {
+                String errorMsg = "UploadFileTask Error, result is " +
+                        (result != null ? "not instance of CompleteMultipartUploadResult!" : "null");
+                errorMsg += (taskRequest.getCancelHandler() != null && taskRequest.getCancelHandler().isCancelled()) ?
+                        ", uploadFileRequest is canceled." : "";
+                log.error(errorMsg);
+                return Optional.empty();
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("UploadFileTask Error:" , e);
+            return Optional.empty();
+        }
+    }
+
+    public void setResultFuture(Future<?> future) {
+        resultFuture = future;
+    }
+
+    public boolean cancel() {
+        if (taskRequest.getCancelHandler() != null) {
+            taskRequest.getCancelHandler().cancel();
+            return true;
+        } else {
+            String errorInfo = "UploadFileTask Cancel Error: CancelHandler is null, can not cancel!";
+            log.error(errorInfo);
+            return false;
+        }
+    }
+
+    protected CompleteMultipartUploadResult uploadFileWithCallBack() {
+        try {
+            CompleteMultipartUploadResult uploadFileResult = getObsClient().uploadFile(taskRequest);
+            completeCallback.onSuccess(uploadFileResult);
+            return uploadFileResult;
+        } catch (ObsException e) {
+            completeCallback.onException(e, taskRequest);
+        } catch (Throwable t) {
+            completeCallback.onException(changeFromThrowable(t), taskRequest);
+        }
+        return null;
+    }
+
+    public boolean isTaskFinished() {
+        return resultFuture.isDone();
+    }
+
+    public void waitUntilFinished() {
+        try {
+            resultFuture.get();
+        } catch (Throwable t) {
+            log.warn("UploadFileTask waitUntilFinished Error:", t);
+        }
+    }
+
+    /**
+     * Computes a result, or throws an exception if unable to do so.
+     *
+     * @return computed result
+     * @throws Exception if unable to compute a result
+     */
+    @Override
+    public Object call() throws Exception {
+        return uploadFileWithCallBack();
+    }
+}

--- a/app/src/main/java/com/obs/services/internal/trans/NewTransResult.java
+++ b/app/src/main/java/com/obs/services/internal/trans/NewTransResult.java
@@ -1,5 +1,6 @@
 package com.obs.services.internal.trans;
 
+import com.obs.services.internal.utils.CallCancelHandler;
 import com.obs.services.model.HttpMethodEnum;
 import okhttp3.RequestBody;
 
@@ -16,6 +17,8 @@ public class NewTransResult {
     private HttpMethodEnum httpMethod;
     private boolean encodeHeaders = false;
     private boolean encodeUrl = true;
+
+    protected CallCancelHandler cancelHandler;
 
     public NewTransResult() {
     }
@@ -104,5 +107,12 @@ public class NewTransResult {
 
     public void setEncodeUrl(boolean encodeUrl) {
         this.encodeUrl = encodeUrl;
+    }
+    public CallCancelHandler getCancelHandler() {
+        return cancelHandler;
+    }
+
+    public void setCancelHandler(CallCancelHandler cancelHandler) {
+        this.cancelHandler = cancelHandler;
     }
 }

--- a/app/src/main/java/com/obs/services/internal/utils/AccessLoggerUtils.java
+++ b/app/src/main/java/com/obs/services/internal/utils/AccessLoggerUtils.java
@@ -42,7 +42,7 @@ public class AccessLoggerUtils {
         }
 
         return new StringBuilder().append(stacktrace.getClassName()).append("|").append(stacktrace.getMethodName())
-                .append("|").append(stacktrace.getLineNumber()).append("|").toString();
+                .append("|line:").append(stacktrace.getLineNumber()).append("|").toString();
     }
 
     private static StringBuilder getLog() {

--- a/app/src/main/java/com/obs/services/internal/utils/CRC64.java
+++ b/app/src/main/java/com/obs/services/internal/utils/CRC64.java
@@ -1,0 +1,392 @@
+package com.obs.services.internal.utils;
+
+import com.obs.log.ILogger;
+import com.obs.log.LoggerBuilder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.zip.Checksum;
+
+public class CRC64 implements Checksum, Serializable {
+    private static final long serialVersionUID = 5684087791018577616L;
+    private static final ILogger log = LoggerBuilder.getLogger(CRC64.class);
+
+    private static final long POLY = (long) 0xc96c5795d7870f42L; // ECMA-182
+
+    /* CRC64 calculation table. */
+    private static final long[][] CRC64_TABLE;
+
+    /* Current CRC value. */
+    private long value;
+
+    /**
+     * Initialize with another CRC64's value.
+     *
+     * @param origin:
+     *              original crc64
+     */
+    public CRC64(CRC64 origin) {
+        this.value = origin.value;
+    }
+
+    /**
+     * Initialize with a value of zero.
+     */
+    public CRC64() {
+        this.value = 0;
+    }
+
+    /**
+     * Initialize with a custom CRC value.
+     *
+     * @param value
+     */
+    public CRC64(long value) {
+        this.value = value;
+    }
+
+    /**
+     * Initialize by calculating the CRC of the given byte blocks.
+     *
+     * @param b
+     *            block of bytes
+     * @param len
+     *            number of bytes to process
+     */
+    public CRC64(byte[] b, int len) {
+        this.value = 0;
+        update(b, len);
+    }
+
+    /**
+     * Initialize by calculating the CRC of the given byte blocks.
+     *
+     * @param b
+     *            block of bytes
+     * @param off
+     *            starting offset of the byte block
+     * @param len
+     *            number of bytes to process
+     */
+    public CRC64(byte[] b, int off, int len) {
+        this.value = 0;
+        update(b, off, len);
+    }
+
+    /**
+     * Calculate the CRC64 of the given file's content.
+     *
+     * @param f
+     * @return new {@link CRC64} instance initialized to the file's CRC value
+     * @throws IOException
+     *             in case the {@link FileInputStream#read(byte[])} method fails
+     */
+    public static CRC64 fromFile(File f) throws IOException {
+        return fromInputStream(new FileInputStream(f));
+    }
+
+    /**
+     * Calculate the CRC64 of the given {@link InputStream} until the end of the
+     * stream has been reached.
+     *
+     * @param in
+     *            the stream will be closed automatically
+     * @return new {@link CRC64} instance initialized to the {@link InputStream}'s CRC value
+     * @throws IOException
+     *             in case the {@link InputStream#read(byte[])} method fails
+     */
+    public static CRC64 fromInputStream(InputStream in) throws IOException {
+        try {
+            CRC64 crc = new CRC64();
+            byte[] b = new byte[4096];
+            int l;
+
+            while ((l = in.read(b)) != -1) {
+                crc.update(b, l);
+            }
+
+            return crc;
+
+        } finally {
+            in.close();
+        }
+    }
+
+    /**
+     * Calculate the CRC64 of the given {@link InputStream} from offset to offset + sizeToReadTotal.
+     *
+     * @param in
+     *            the stream will be closed automatically
+     * @param offset
+     *            the start offset in stream in at which the data is read.
+     * @param sizeToReadTotal
+     *            the maximum number of bytes to read.
+     * @return new {@link CRC64} instance initialized to the {@link InputStream}'s CRC value
+     * @throws IOException
+     *             in case the {@link InputStream#read(byte[])} method fails
+     */
+    public static CRC64 fromInputStream(InputStream in, long offset, long sizeToReadTotal) throws IOException {
+        try {
+            long skippedSize = in.skip(offset);
+            if (skippedSize != offset) {
+                String errorInfo =
+                        "Failed to skip the input stream to the specified offset:"
+                                + offset
+                                + ". actual skip size is "
+                                + skippedSize;
+                log.error(errorInfo);
+                throw new IOException(errorInfo);
+            }
+            CRC64 crc = new CRC64();
+            int bufferSize = 4096;
+            byte[] b = new byte[bufferSize];
+            int l;
+            long sizeToRead = Long.min(sizeToReadTotal, bufferSize);
+            while (sizeToRead > 0 && (l = in.read(b, 0, (int) sizeToRead)) != -1) {
+                crc.update(b, l);
+                sizeToReadTotal -= l;
+                sizeToRead = Long.min(sizeToReadTotal, bufferSize);
+            }
+            return crc;
+
+        } finally {
+            in.close();
+        }
+    }
+
+    /**
+     * Get long representation of current CRC64 value.
+     */
+    public long getValue() {
+        return this.value;
+    }
+
+    /**
+     * Set long representation of current CRC64 value.
+     */
+    public void setValue(long value) {
+        this.value = value;
+    }
+
+    /**
+     * Update CRC64 with new byte block.
+     */
+    public void update(byte[] b, int len) {
+        this.update(b, 0, len);
+    }
+
+    /**
+     * Update CRC64 with new byte block.
+     */
+    public void update(byte[] b, int off, int len) {
+        this.value = ~this.value;
+
+        /* fast middle processing, 8 bytes (aligned!) per loop */
+
+        int idx = off;
+        while (len >= 8) {
+            value =
+                    CRC64_TABLE[7][(int) (value & 0xff ^ (b[idx] & 0xff))]
+                            ^ CRC64_TABLE[6][(int) ((value >>> 8) & 0xff ^ (b[idx + 1] & 0xff))]
+                            ^ CRC64_TABLE[5][(int) ((value >>> 16) & 0xff ^ (b[idx + 2] & 0xff))]
+                            ^ CRC64_TABLE[4][(int) ((value >>> 24) & 0xff ^ (b[idx + 3] & 0xff))]
+                            ^ CRC64_TABLE[3][(int) ((value >>> 32) & 0xff ^ (b[idx + 4] & 0xff))]
+                            ^ CRC64_TABLE[2][(int) ((value >>> 40) & 0xff ^ (b[idx + 5] & 0xff))]
+                            ^ CRC64_TABLE[1][(int) ((value >>> 48) & 0xff ^ (b[idx + 6] & 0xff))]
+                            ^ CRC64_TABLE[0][(int) ((value >>> 56) ^ b[idx + 7] & 0xff)];
+            idx += 8;
+            len -= 8;
+        }
+
+        /* process remaining bytes (can't be larger than 8) */
+        while (len > 0) {
+            value = CRC64_TABLE[0][(int) ((this.value ^ b[idx]) & 0xff)] ^ (this.value >>> 8);
+            idx++;
+            len--;
+        }
+
+        this.value = ~this.value;
+    }
+
+    public void update(int b) {
+        this.update(new byte[] {(byte) b}, 0, 1);
+    }
+
+    public void reset() {
+        this.value = 0;
+    }
+
+    // dimension of GF(2) vectors (length of CRC)
+    private static final int GF2_DIM = 64;
+
+    private static long gf2MatrixTimes(long[] mat, long vec) {
+        long sum = 0L;
+        int idx = 0;
+        while (vec != 0) {
+            if ((vec & 1) == 1) {
+                sum ^= mat[idx];
+            }
+            vec >>>= 1;
+            idx++;
+        }
+        return sum;
+    }
+
+    private static void gf2MatrixSquare(long[] square, long[] mat) {
+        for (int n = 0; n < GF2_DIM; n++) {
+            square[n] = gf2MatrixTimes(mat, mat[n]);
+        }
+    }
+
+    /*
+     * calculate the CRC-64 of two sequential blocks and set it to this.value,
+     * where this.value is the CRC-64 of the first block,
+     * anotherCRC64.value is the CRC-64 of the second block, and len2 is the
+     * length of the second block.
+     */
+    public void combineWithAnotherCRC64(CRC64 anotherCRC64, long len2) {
+        this.value = combine(this.value, anotherCRC64.value, len2);
+    }
+
+    private static final long[] EVEN_SQUARE;
+    private static final long[] ODD_SQUARE;
+
+    static {
+        /*
+         * Nested tables as described by Mark Adler
+         */
+        CRC64_TABLE = new long[8][256];
+
+        for (int n = 0; n < 256; n++) {
+            long crc = n;
+            for (int k = 0; k < 8; k++) {
+                if ((crc & 1) == 1) {
+                    crc = (crc >>> 1) ^ POLY;
+                } else {
+                    crc = (crc >>> 1);
+                }
+            }
+            CRC64_TABLE[0][n] = crc;
+        }
+
+        /* generate nested CRC table for future slice-by-8 lookup */
+        for (int n = 0; n < 256; n++) {
+            long crc = CRC64_TABLE[0][n];
+            for (int k = 1; k < 8; k++) {
+                crc = CRC64_TABLE[0][(int) (crc & 0xff)] ^ (crc >>> 8);
+                CRC64_TABLE[k][n] = crc;
+            }
+        }
+
+        int n;
+        long row;
+        EVEN_SQUARE = new long[GF2_DIM]; // even-power-of-two zeros operator
+        ODD_SQUARE = new long[GF2_DIM]; // odd-power-of-two zeros operator
+        // put operator for one zero bit in odd
+        ODD_SQUARE[0] = POLY; // CRC-64 polynomial
+        row = 1;
+        for (n = 1; n < GF2_DIM; n++) {
+            ODD_SQUARE[n] = row;
+            row <<= 1;
+        }
+        // put operator for two zero bits in even
+        gf2MatrixSquare(EVEN_SQUARE, ODD_SQUARE);
+        // put operator for four zero bits in odd
+        gf2MatrixSquare(ODD_SQUARE, EVEN_SQUARE);
+    }
+
+    /*
+     * Return the CRC-64 of two sequential blocks, where crc1 is the CRC-64 of
+     * the first block, crc2 is the CRC-64 of the second block, and len2 is the
+     * length of the second block.
+     */
+    public static long combine(long crc1, long crc2, long len2) {
+        // degenerate case.
+        if (len2 == 0) {
+            return crc1;
+        }
+
+        long[] even = Arrays.copyOf(EVEN_SQUARE, EVEN_SQUARE.length);
+        long[] odd = Arrays.copyOf(ODD_SQUARE, ODD_SQUARE.length);
+        // apply len2 zeros to crc1 (first square will put the operator for one
+        // zero byte, eight zero bits, in even)
+        do {
+            // apply zeros operator for this bit of len2
+            gf2MatrixSquare(even, odd);
+            if ((len2 & 1) == 1) {
+                crc1 = gf2MatrixTimes(even, crc1);
+            }
+            len2 >>>= 1;
+
+            // if no more bits set, then done
+            if (len2 == 0) {
+                break;
+            }
+
+            // another iteration of the loop with odd and even swapped
+            gf2MatrixSquare(odd, even);
+            if ((len2 & 1) == 1) {
+                crc1 = gf2MatrixTimes(odd, crc1);
+            }
+            len2 >>>= 1;
+
+            // if no more bits set, then done
+        } while (len2 != 0);
+        // return combined crc.
+        crc1 ^= crc2;
+        return crc1;
+    }
+
+    /**
+     * Returns a string representation of the object. In general, the
+     * {@code toString} method returns a string that
+     * "textually represents" this object. The result should
+     * be a concise but informative representation that is easy for a
+     * person to read.
+     * It is recommended that all subclasses override this method.
+     * <p>
+     * The {@code toString} method for class {@code Object}
+     * returns a string consisting of the name of the class of which the
+     * object is an instance, the at-sign character `{@code @}', and
+     * the unsigned hexadecimal representation of the hash code of the
+     * object. In other words, this method returns a string equal to the
+     * value of:
+     * <blockquote>
+     * <pre>
+     * getClass().getName() + '@' + Integer.toHexString(hashCode())
+     * </pre></blockquote>
+     *
+     * @return a string representation of the object.
+     */
+    @Override
+    public String toString() {
+        return Long.toUnsignedString(this.value);
+    }
+
+    public static String toString(long value) {
+        return Long.toUnsignedString(value);
+    }
+
+    public static long fromString(String crcString) throws NumberFormatException {
+        return Long.parseUnsignedLong(crcString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(this.value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj instanceof CRC64) {
+            return ((CRC64) obj).value == this.value;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/com/obs/services/internal/utils/CRC64InputStream.java
+++ b/app/src/main/java/com/obs/services/internal/utils/CRC64InputStream.java
@@ -1,0 +1,92 @@
+package com.obs.services.internal.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CRC64InputStream extends InputStream {
+    private final InputStream inputStream;
+
+    public CRC64 getCrc64() {
+        return crc64;
+    }
+
+    private final CRC64 crc64;
+
+    public CRC64InputStream(InputStream inputStream) {
+        this.inputStream = inputStream;
+        this.crc64 = new CRC64();
+    }
+
+    /**
+     * Reads the next byte of data from the input stream. The value byte is
+     * returned as an <code>int</code> in the range <code>0</code> to
+     * <code>255</code>. If no byte is available because the end of the stream
+     * has been reached, the value <code>-1</code> is returned. This method
+     * blocks until input data is available, the end of the stream is detected,
+     * or an exception is thrown.
+     *
+     * <p> A subclass must provide an implementation of this method.
+     *
+     * @return the next byte of data, or <code>-1</code> if the end of the
+     * stream is reached.
+     * @throws IOException if an I/O error occurs.
+     */
+    @Override
+    public int read() throws IOException {
+        int byteRead = this.inputStream.read();
+        if (byteRead != -1) {
+            crc64.update(byteRead);
+        }
+        return byteRead;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int bytesRead = inputStream.read(b, off, len);
+        if (bytesRead != -1) {
+            crc64.update(b, off, bytesRead);
+        }
+        return bytesRead;
+    }
+    @Override
+    public long skip(long n) throws IOException {
+        byte[] buffer = new byte[512];
+        long totalSkippedBytes = 0L;
+        long skippedBytes;
+        long remainBytesToSkip;
+        while (totalSkippedBytes < n) {
+            remainBytesToSkip = n - totalSkippedBytes;
+            skippedBytes =
+                    read(buffer, 0, remainBytesToSkip < buffer.length ? (int) remainBytesToSkip : buffer.length);
+            if (skippedBytes == -1) {
+                return totalSkippedBytes;
+            }
+            totalSkippedBytes += skippedBytes;
+        }
+        return totalSkippedBytes;
+    }
+    @Override
+    public int available() throws IOException {
+        return inputStream.available();
+    }
+    @Override
+    public synchronized void mark(int readlimit) {
+        inputStream.mark(readlimit);
+    }
+    @Override
+    public boolean markSupported() {
+        return inputStream.markSupported();
+    }
+
+    /**
+     * Closes this input stream and releases any system resources associated
+     * with the stream.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+        super.close();
+    }
+}

--- a/app/src/main/java/com/obs/services/internal/utils/CallCancelHandler.java
+++ b/app/src/main/java/com/obs/services/internal/utils/CallCancelHandler.java
@@ -1,0 +1,79 @@
+package com.obs.services.internal.utils;
+
+import com.obs.log.ILogger;
+import com.obs.log.LoggerBuilder;
+import com.obs.services.exception.ObsException;
+
+import okhttp3.Call;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CallCancelHandler
+{
+    private final AtomicInteger maxCancelQueueCapacity = new AtomicInteger(0);
+    protected static final ILogger log = LoggerBuilder.getLogger(CallCancelHandler.class);
+    protected AtomicBoolean isCancelled = new AtomicBoolean(false);
+
+    protected ConcurrentLinkedQueue<Call> calls = new ConcurrentLinkedQueue<>();
+
+    /**
+     * cancel
+     *
+     */
+    public void cancel() {
+        isCancelled.set(true);
+        calls.forEach(
+                call -> {
+                    if (call != null && !call.isCanceled()) {
+                        call.cancel();
+                    }
+                });
+        calls.clear();
+    }
+
+    public boolean isCancelled() {
+        return isCancelled.get();
+    }
+
+    public void setCall(Call call) {
+        if (this.isCancelled.get()) {
+            String msg = "transport is cancelled";
+            if (call == null) {
+                msg += ", call is null";
+            } else if(call.request() == null) {
+                msg += ", call's request is null";
+            } else {
+                msg += (", url :" + call.request().url());
+            }
+            log.warn(msg);
+            throw new ObsException("transport is cancelled by cancelHandler");
+        }
+        if (calls.size() >= maxCancelQueueCapacity.get()) {
+            log.debug(
+                    this.getClass().getName()
+                            + "'s calls Capacity is full. cancel may not working! "
+                            + "try adjust it by setMaxCallCapacity");
+        } else {
+            this.calls.add(call);
+        }
+    }
+
+    public void removeFinishedCall(Call call) {
+        calls.remove(call);
+    }
+
+    public void resetCancelStatus() {
+        calls.clear();
+        isCancelled.set(false);
+    }
+
+    public int getMaxCallCapacity() {
+        return maxCancelQueueCapacity.get();
+    }
+
+    public void setMaxCallCapacity(int maxCancelQueueCapacity) {
+        this.maxCancelQueueCapacity.set(maxCancelQueueCapacity);
+    }
+}

--- a/app/src/main/java/com/obs/services/internal/utils/OkhttpCallProfiler.java
+++ b/app/src/main/java/com/obs/services/internal/utils/OkhttpCallProfiler.java
@@ -1,0 +1,591 @@
+package com.obs.services.internal.utils;
+
+import com.obs.log.ILogger;
+import com.obs.log.LoggerBuilder;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.EventListener;
+import okhttp3.Handshake;
+import okhttp3.HttpUrl;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class OkhttpCallProfiler extends EventListener {
+    private final Consumer<StringBuilder> profiler;
+    private final HashMap<String, Long> progressStartTime;
+    private static final ILogger log = LoggerBuilder.getLogger("com.obs.services.ObsClient");
+    private static final String ProFileTimeUnit = "ms";
+    static protected boolean isEnabled = true;
+
+    public OkhttpCallProfiler(Consumer<StringBuilder> profiler) {
+        this.profiler = profiler;
+        progressStartTime = new HashMap<>();
+    }
+
+    public OkhttpCallProfiler() {
+        this.profiler = log::debug;
+        progressStartTime = new HashMap<>();
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void callEnd(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" callEnd ");
+        appendProgressTime("call", stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param ioe
+     */
+    @Override
+    public void callFailed(Call call, IOException ioe) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" callFailed ");
+        appendProgressTime("call", stringBuilder);
+        appendDetailIOException(ioe, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void callStart(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" callStart ");
+        appendProgressTime("call", stringBuilder);
+        appendDetailForCall(call, stringBuilder, true);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void canceled(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" call canceled.");
+        appendProgressTime("call", stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param inetSocketAddress
+     * @param proxy
+     * @param protocol
+     */
+    @Override
+    public void connectEnd(Call call, InetSocketAddress inetSocketAddress, Proxy proxy, Protocol protocol) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" connectEnd ");
+        appendProgressTime("connect", stringBuilder);
+        appendDetailInetSocketAddress(inetSocketAddress, stringBuilder);
+        appendDetailProxy(proxy, stringBuilder);
+        appendDetailProtocol(protocol, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param inetSocketAddress
+     * @param proxy
+     * @param protocol
+     * @param ioe
+     */
+    @Override
+    public void connectFailed(
+            Call call, InetSocketAddress inetSocketAddress, Proxy proxy, Protocol protocol, IOException ioe) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" connectFailed ");
+        appendProgressTime("connect", stringBuilder);
+        appendDetailInetSocketAddress(inetSocketAddress, stringBuilder);
+        appendDetailProxy(proxy, stringBuilder);
+        appendDetailProtocol(protocol, stringBuilder);
+        appendDetailIOException(ioe, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param inetSocketAddress
+     * @param proxy
+     */
+    @Override
+    public void connectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" connectStart ");
+        appendProgressTime("connect", stringBuilder);
+        appendDetailInetSocketAddress(inetSocketAddress, stringBuilder);
+        appendDetailProxy(proxy, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param connection
+     */
+    @Override
+    public void connectionAcquired(Call call, Connection connection) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" connectionAcquired ");
+        appendProgressTime("connection", stringBuilder);
+        appendDetailConnection(connection, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param connection
+     */
+    @Override
+    public void connectionReleased(Call call, Connection connection) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" connectionReleased ");
+        appendProgressTime("connection", stringBuilder);
+        appendDetailConnection(connection, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param domainName
+     * @param inetAddressList
+     */
+    @Override
+    public void dnsEnd(Call call, String domainName, List<InetAddress> inetAddressList) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" dnsEnd ");
+        appendProgressTime("dns", stringBuilder);
+        appendDetailDns(domainName, inetAddressList, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param domainName
+     */
+    @Override
+    public void dnsStart(Call call, String domainName) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" dnsStart ");
+        appendProgressTime("dns", stringBuilder);
+        appendDetailDns(domainName, null, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param url
+     * @param proxies
+     */
+    @Override
+    public void proxySelectEnd(Call call, HttpUrl url, List<Proxy> proxies) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" proxySelectEnd ");
+        appendProgressTime("proxySelect", stringBuilder);
+        stringBuilder.append(" url{");
+        stringBuilder.append(url);
+        stringBuilder.append("} ");
+        stringBuilder.append(" proxies{");
+        stringBuilder.append(proxies);
+        stringBuilder.append("} ");
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param url
+     */
+    @Override
+    public void proxySelectStart(Call call, HttpUrl url) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" proxySelectStart ");
+        appendProgressTime("proxySelect", stringBuilder);
+        stringBuilder.append(" url{");
+        stringBuilder.append(url);
+        stringBuilder.append("} ");
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param byteCount
+     */
+    @Override
+    public void requestBodyEnd(Call call, long byteCount) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" requestBodyEnd ");
+        appendProgressTime("requestBody", stringBuilder);
+        appendProgressTime("request", stringBuilder);
+        stringBuilder.append(" byteCount{");
+        stringBuilder.append(byteCount);
+        stringBuilder.append("} ");
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void requestBodyStart(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" requestBodyStart ");
+        appendProgressTime("requestBody", stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param ioe
+     */
+    @Override
+    public void requestFailed(Call call, IOException ioe) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" requestFailed ");
+        appendProgressTime("request", stringBuilder);
+        appendDetailIOException(ioe, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param request
+     */
+    @Override
+    public void requestHeadersEnd(Call call, Request request) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" requestHeadersEnd ");
+        appendProgressTime("requestHeaders", stringBuilder);
+        appendDetailRequestHeaders(request, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void requestHeadersStart(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" requestHeadersStart ");
+        appendProgressTime("request", stringBuilder);
+        appendProgressTime("requestHeaders", stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param byteCount
+     */
+    @Override
+    public void responseBodyEnd(Call call, long byteCount) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" responseBodyEnd ");
+        appendProgressTime("responseBody", stringBuilder);
+        appendProgressTime("response", stringBuilder);
+        stringBuilder.append(" byteCount{");
+        stringBuilder.append(byteCount);
+        stringBuilder.append("} ");
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void responseBodyStart(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" responseBodyStart ");
+        appendProgressTime("responseBody", stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param ioe
+     */
+    @Override
+    public void responseFailed(Call call, IOException ioe) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" responseFailed ");
+        appendProgressTime("response", stringBuilder);
+        appendDetailIOException(ioe, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param response
+     */
+    @Override
+    public void responseHeadersEnd(Call call, Response response) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" responseHeadersEnd ");
+        appendProgressTime("responseHeaders", stringBuilder);
+        appendDetailResponseHeaders(response, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void responseHeadersStart(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" responseHeadersStart ");
+        appendProgressTime("response", stringBuilder);
+        appendProgressTime("responseHeaders", stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     * @param handshake
+     */
+    @Override
+    public void secureConnectEnd(Call call, Handshake handshake) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" secureConnectEnd ");
+        appendProgressTime("secureConnect", stringBuilder);
+        appendDetailHandshake(handshake, stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    /**
+     * @param call
+     */
+    @Override
+    public void secureConnectStart(Call call) {
+        if (!isEnabled) {
+            return;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(" secureConnectStart ");
+        appendProgressTime("secureConnect", stringBuilder);
+        appendDetailForCall(call, stringBuilder);
+        profiler.accept(stringBuilder);
+    }
+
+    protected void appendProgressTime(String progressName, StringBuilder stringBuilder) {
+        Long startTime = this.progressStartTime.get(progressName);
+        if (startTime == null) {
+            startTime = System.currentTimeMillis();
+            this.progressStartTime.put(progressName, startTime);
+            stringBuilder.append(progressName);
+            stringBuilder.append(" start time: ");
+            stringBuilder.append(startTime);
+            stringBuilder.append(ProFileTimeUnit);
+            stringBuilder.append(" ");
+        } else {
+            long currentTime = System.currentTimeMillis();
+            long costTime = currentTime - startTime;
+            this.progressStartTime.remove(progressName, startTime);
+            stringBuilder.append(progressName);
+            stringBuilder.append(" cost time: ");
+            stringBuilder.append(costTime);
+            stringBuilder.append(ProFileTimeUnit);
+            stringBuilder.append(" end time: ");
+            stringBuilder.append(currentTime);
+            stringBuilder.append(ProFileTimeUnit);
+            stringBuilder.append(" ");
+        }
+    }
+
+    protected void appendDetailForCall(Call call, StringBuilder stringBuilder) {
+        appendDetailForCall(call, stringBuilder, false);
+    }
+    protected void appendDetailForCall(Call call, StringBuilder stringBuilder, boolean needDetail) {
+        stringBuilder.append("call {");
+        if (needDetail) {
+            stringBuilder.append("url:");
+            stringBuilder.append(call.request().url());
+            stringBuilder.append(" method:");
+            stringBuilder.append(call.request().method());
+            stringBuilder.append(" ");
+        }
+        stringBuilder.append("hash:");
+        stringBuilder.append(System.identityHashCode(call));
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailInetSocketAddress(InetSocketAddress inetSocketAddress, StringBuilder stringBuilder) {
+        stringBuilder.append(" InetSocketAddress {");
+        stringBuilder.append(inetSocketAddress);
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailProxy(Proxy proxy, StringBuilder stringBuilder) {
+        stringBuilder.append(" Proxy {type:");
+        stringBuilder.append(proxy.type());
+        stringBuilder.append(" address:");
+        stringBuilder.append(proxy.address());
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailProtocol(Protocol protocol, StringBuilder stringBuilder) {
+        stringBuilder.append(" Protocol{");
+        stringBuilder.append(protocol);
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailConnection(Connection connection, StringBuilder stringBuilder) {
+        stringBuilder.append(" ");
+        stringBuilder.append(connection);
+        stringBuilder.append(" ");
+    }
+
+    protected void appendDetailDns(String domainName, List<InetAddress> inetAddressList, StringBuilder stringBuilder) {
+        stringBuilder.append(" domainName:");
+        stringBuilder.append(domainName);
+        stringBuilder.append(" inetAddressList{");
+        stringBuilder.append(inetAddressList);
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailRequestHeaders(Request request, StringBuilder stringBuilder) {
+        stringBuilder.append(" requestHeaders{");
+        stringBuilder.append(request.headers());
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailResponseHeaders(Response response, StringBuilder stringBuilder) {
+        stringBuilder.append(" responseHeaders{");
+        stringBuilder.append(response.headers());
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailHandshake(Handshake handshake, StringBuilder stringBuilder) {
+        stringBuilder.append(" handshake{");
+        stringBuilder.append(handshake);
+        stringBuilder.append("} ");
+    }
+
+    protected void appendDetailIOException(IOException ioe, StringBuilder stringBuilder) {
+        try (StringWriter stringWriter = new StringWriter();
+                PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            ioe.printStackTrace(printWriter);
+            stringBuilder.append(stringWriter);
+        } catch (IOException ignore) {
+            stringBuilder.append("appendDetailIOException failed");
+        }
+    }
+
+    public static boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public static void setEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+}

--- a/app/src/main/java/com/obs/services/internal/utils/RestUtils.java
+++ b/app/src/main/java/com/obs/services/internal/utils/RestUtils.java
@@ -29,12 +29,12 @@ import okhttp3.ConnectionPool;
 import okhttp3.Credentials;
 import okhttp3.Dispatcher;
 import okhttp3.Dns;
+import okhttp3.EventListener;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
-import org.jetbrains.annotations.NotNull;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.HostnameVerifier;
@@ -333,7 +333,8 @@ public class RestUtils {
 
     public static OkHttpClient.Builder initHttpClientBuilder(ObsProperties obsProperties,
             KeyManagerFactory keyManagerFactory, TrustManagerFactory trustManagerFactory,
-            Dispatcher httpDispatcher, Dns customizedDnsImpl, HostnameVerifier userHostnameVerifier, SecureRandom secureRandom) {
+            Dispatcher httpDispatcher, Dns customizedDnsImpl, EventListener.Factory eventListenerFactory,
+            HostnameVerifier userHostnameVerifier, SecureRandom secureRandom) {
 
         List<Protocol> protocols = new ArrayList<Protocol>(2);
         protocols.add(Protocol.HTTP_1_1);
@@ -383,6 +384,10 @@ public class RestUtils {
                 .connectionPool(pool)
                 .hostnameVerifier(hostnameVerifier)
                 .dns(dns);
+
+        if (eventListenerFactory != null) {
+            builder.eventListenerFactory(eventListenerFactory);
+        }
 
         int socketReadBufferSize = obsProperties.getIntProperty(ObsConstraint.SOCKET_READ_BUFFER_SIZE, -1);
         int socketWriteBufferSize = obsProperties.getIntProperty(ObsConstraint.SOCKET_WRITE_BUFFER_SIZE, -1);
@@ -501,9 +506,8 @@ public class RestUtils {
          * @return
          * @throws UnknownHostException
          */
-        @NotNull
         @Override
-        public List<InetAddress> lookup(@NotNull String hostname) throws UnknownHostException {
+        public List<InetAddress> lookup(String hostname) throws UnknownHostException {
             List<InetAddress> adds = Dns.SYSTEM.lookup(hostname);
             log.info("internet host address:" + adds);
             return adds;

--- a/app/src/main/java/com/obs/services/internal/utils/SecureObjectInputStream.java
+++ b/app/src/main/java/com/obs/services/internal/utils/SecureObjectInputStream.java
@@ -33,7 +33,16 @@ public final class SecureObjectInputStream extends ObjectInputStream {
                     "com.obs.services.internal.UploadResumableClient$UploadPart",
                     "com.obs.services.internal.DownloadResumableClient$DownloadCheckPoint",
                     "com.obs.services.internal.DownloadResumableClient$DownloadPart",
-                    "com.obs.services.internal.DownloadResumableClient$ObjectStatus"));
+                    "com.obs.services.internal.DownloadResumableClient$ObjectStatus",
+                    "com.obs.services.internal.utils.CRC64",
+                    "java.util.concurrent.ConcurrentHashMap",
+                    "[Ljava.util.concurrent.ConcurrentHashMap$Segment;",
+                    "java.util.concurrent.ConcurrentHashMap$Segment",
+                    "java.util.concurrent.locks.ReentrantLock",
+                    "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+                    "java.util.concurrent.locks.ReentrantLock$Sync",
+                    "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+                    "java.util.concurrent.locks.AbstractOwnableSynchronizer"));
 
     public SecureObjectInputStream() throws IOException, SecurityException {
         super();

--- a/app/src/main/java/com/obs/services/internal/xml/OBSXMLBuilder.java
+++ b/app/src/main/java/com/obs/services/internal/xml/OBSXMLBuilder.java
@@ -337,9 +337,14 @@ public class OBSXMLBuilder {
         }
         Transformer transformer = tf.newTransformer();
         transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-        StringWriter writer = new StringWriter();
-        transformer.transform(new DOMSource(this.getDocument()), new StreamResult(writer));
-        return writer.getBuffer().toString().replaceAll("|\r", "");
+        try (StringWriter writer = new StringWriter()) {
+            transformer.transform(new DOMSource(this.getDocument()), new StreamResult(writer));
+            return writer.getBuffer().toString().replaceAll("|\r", "");
+        } catch (IOException e) {
+            log.error("Transformer.transform failed, detail:", e);
+            throw new TransformerException(e);
+        }
+
     }
 
     public int hashCode() throws UnsupportedOperationException {

--- a/app/src/main/java/com/obs/services/model/AppendObjectRequest.java
+++ b/app/src/main/java/com/obs/services/model/AppendObjectRequest.java
@@ -24,6 +24,8 @@ public class AppendObjectRequest extends PutObjectRequest {
 
     protected long position;
 
+    protected String crc64BeforeAppend;
+
     {
         this.httpMethod = HttpMethodEnum.POST;
     }
@@ -54,4 +56,11 @@ public class AppendObjectRequest extends PutObjectRequest {
         this.position = position;
     }
 
+    public String getCrc64BeforeAppend() {
+        return crc64BeforeAppend;
+    }
+
+    public void setCrc64BeforeAppend(String crc64BeforeAppend) {
+        this.crc64BeforeAppend = crc64BeforeAppend;
+    }
 }

--- a/app/src/main/java/com/obs/services/model/AppendObjectResult.java
+++ b/app/src/main/java/com/obs/services/model/AppendObjectResult.java
@@ -14,6 +14,8 @@
 
 package com.obs.services.model;
 
+import com.obs.services.internal.utils.CRC64;
+
 /**
  * Response to an appendable upload request
  *
@@ -31,6 +33,8 @@ public class AppendObjectResult extends HeaderResponse {
     private StorageClassEnum storageClass;
 
     private String objectUrl;
+
+    private CRC64 clientCalculatedCRC64;
 
     public AppendObjectResult(String bucketName, String objectKey, String etag, long nextPosition,
             StorageClassEnum storageClass, String objectUrl) {
@@ -96,10 +100,19 @@ public class AppendObjectResult extends HeaderResponse {
         return objectUrl;
     }
 
+    public CRC64 getClientCalculatedCRC64() {
+        return clientCalculatedCRC64;
+    }
+
+    public void setClientCalculatedCRC64(CRC64 clientCalculatedCRC64) {
+        this.clientCalculatedCRC64 = clientCalculatedCRC64;
+    }
+
     @Override
     public String toString() {
         return "AppendObjectResult [bucketName=" + bucketName + ", objectKey=" + objectKey + ", etag=" + etag
-                + ", nextPosition=" + nextPosition + ", storageClass=" + storageClass + ", objectUrl=" + objectUrl
+                + ", nextPosition=" + nextPosition + ", storageClass=" + storageClass + ", objectUrl=" + objectUrl +
+                ", clientCalculatedCRC64=" + clientCalculatedCRC64
                 + "]";
     }
 

--- a/app/src/main/java/com/obs/services/model/CopyObjectResult.java
+++ b/app/src/main/java/com/obs/services/model/CopyObjectResult.java
@@ -24,6 +24,8 @@ import com.obs.services.internal.utils.ServiceUtils;
 public class CopyObjectResult extends HeaderResponse {
     private String etag;
 
+    private String crc64;
+
     private Date lastModified;
 
     private String versionId;
@@ -33,12 +35,13 @@ public class CopyObjectResult extends HeaderResponse {
     private StorageClassEnum storageClass;
 
     public CopyObjectResult(String etag, Date lastModified, String versionId, String copySourceVersionId,
-            StorageClassEnum storageClass) {
+            StorageClassEnum storageClass, String crc64) {
         this.etag = etag;
         this.lastModified = ServiceUtils.cloneDateIgnoreNull(lastModified);
         this.versionId = versionId;
         this.copySourceVersionId = copySourceVersionId;
         this.storageClass = storageClass;
+        this.crc64 = crc64;
     }
 
     /**
@@ -84,6 +87,15 @@ public class CopyObjectResult extends HeaderResponse {
      */
     public StorageClassEnum getObjectStorageClass() {
         return storageClass;
+    }
+
+    /**
+     * Obtain the crc64 of the destination object.
+     *
+     * @return crc64 value of the destination object
+     */
+    public String getCRC64() {
+        return crc64;
     }
 
     @Override

--- a/app/src/main/java/com/obs/services/model/CopyPartResult.java
+++ b/app/src/main/java/com/obs/services/model/CopyPartResult.java
@@ -27,11 +27,13 @@ public class CopyPartResult extends HeaderResponse {
     private String etag;
 
     private Date lastModified;
+    private String crc64;
 
-    public CopyPartResult(int partNumber, String etag, Date lastModified) {
+    public CopyPartResult(int partNumber, String etag, Date lastModified, String crc64) {
         this.partNumber = partNumber;
         this.etag = etag;
         this.lastModified = ServiceUtils.cloneDateIgnoreNull(lastModified);
+        this.crc64 = crc64;
     }
 
     /**
@@ -53,6 +55,15 @@ public class CopyPartResult extends HeaderResponse {
     }
 
     /**
+     * Obtain the crc64 of the copied part.
+     *
+     * @return crc64 of the copied part
+     */
+    public String getCrc64() {
+        return crc64;
+    }
+
+    /**
      * Obtain the last modification time of the to-be-copied part.
      * 
      * @return Last modification time of the to-be-copied part
@@ -63,7 +74,8 @@ public class CopyPartResult extends HeaderResponse {
 
     @Override
     public String toString() {
-        return "CopyPartResult [partNumber=" + partNumber + ", etag=" + etag + ", lastModified=" + lastModified + "]";
+        return "CopyPartResult [partNumber=" + partNumber + ", etag=" + etag + ", lastModified=" + lastModified
+                + ", crc64=" + crc64 + "]";
     }
 
 }

--- a/app/src/main/java/com/obs/services/model/DownloadFileRequest.java
+++ b/app/src/main/java/com/obs/services/model/DownloadFileRequest.java
@@ -51,6 +51,8 @@ public class DownloadFileRequest extends BaseObjectRequest {
 
     private long ttl;
 
+    private boolean needCalculateCRC64 = false;
+
     /**
      * Constructor
      * 
@@ -517,6 +519,23 @@ public class DownloadFileRequest extends BaseObjectRequest {
             ttl = 60 * 60 * 24L;
         }
         this.ttl = ttl;
+    }
+
+
+    /**
+     * @return
+     * Whether you need sdk to calculate CRC64 value and compare it with CRC64 returned by server
+     */
+    public boolean isNeedCalculateCRC64() {
+        return needCalculateCRC64;
+    }
+
+    /**
+     * @param needCalculateCRC64
+     * Whether you need sdk to calculate CRC64 value and compare it with CRC64 returned by server
+     */
+    public void setNeedCalculateCRC64(boolean needCalculateCRC64) {
+        this.needCalculateCRC64 = needCalculateCRC64;
     }
 
 

--- a/app/src/main/java/com/obs/services/model/DownloadFileResult.java
+++ b/app/src/main/java/com/obs/services/model/DownloadFileResult.java
@@ -14,10 +14,14 @@
 
 package com.obs.services.model;
 
+import com.obs.services.internal.utils.CRC64;
+
 /**
  * Response to a file download request
  */
 public class DownloadFileResult {
+    private CRC64 crc64Combined;
+
     /**
      * Obtain object properties.
      * 
@@ -39,9 +43,17 @@ public class DownloadFileResult {
 
     private ObjectMetadata objectMetadata;
 
+
+    public CRC64 getCombinedCRC64() {
+        return crc64Combined;
+    }
+    public void setCombinedCRC64(CRC64 crc64Combined) {
+        this.crc64Combined = crc64Combined;
+    }
+
     @Override
     public String toString() {
-        return "DownloadFileResult [objectMetadata=" + objectMetadata + "]";
+        return "DownloadFileResult [objectMetadata=" + objectMetadata + ". crc64Combined=" + crc64Combined + "]";
     }
 
 }

--- a/app/src/main/java/com/obs/services/model/GenericRequest.java
+++ b/app/src/main/java/com/obs/services/model/GenericRequest.java
@@ -14,6 +14,8 @@
 
 package com.obs.services.model;
 
+import com.obs.services.internal.utils.CallCancelHandler;
+
 import java.util.HashMap;
 
 /**
@@ -111,4 +113,13 @@ public class GenericRequest {
     public String toString() {
         return "GenericRequest [isRequesterPays=" + isRequesterPays + "]";
     }
+    public CallCancelHandler getCancelHandler() {
+        return cancelHandler;
+    }
+
+    public void setCancelHandler(CallCancelHandler cancelHandler) {
+        this.cancelHandler = cancelHandler;
+    }
+
+    protected CallCancelHandler cancelHandler;
 }

--- a/app/src/main/java/com/obs/services/model/ModifyObjectRequest.java
+++ b/app/src/main/java/com/obs/services/model/ModifyObjectRequest.java
@@ -112,4 +112,22 @@ public class ModifyObjectRequest extends AppendObjectRequest {
         this.input = input;
         this.position = position;
     }
+
+    /**
+     * @return Whether you need sdk to calculate CRC64 value and check it by adding to header
+     */
+    @Override
+    public boolean isNeedCalculateCRC64() {
+        // not supported in this API
+        return false;
+    }
+
+    /**
+     * @param needCalculateCRC64 Whether you need sdk to calculate CRC64 value and check it by adding to header
+     */
+    @Override
+    public void setNeedCalculateCRC64(boolean needCalculateCRC64) throws IllegalArgumentException {
+        // not supported in this API
+        throw new IllegalArgumentException("not supported in this API");
+    }
 }

--- a/app/src/main/java/com/obs/services/model/ObjectTaggingRequest.java
+++ b/app/src/main/java/com/obs/services/model/ObjectTaggingRequest.java
@@ -12,7 +12,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
- package com.obs.services.model;
+package com.obs.services.model;
 
 /**
  * Request for setting tags for a object

--- a/app/src/main/java/com/obs/services/model/PutObjectRequest.java
+++ b/app/src/main/java/com/obs/services/model/PutObjectRequest.java
@@ -41,6 +41,8 @@ public class PutObjectRequest extends PutObjectBasicRequest {
 
     private Callback callback;
 
+    private boolean needCalculateCRC64 = false;
+
     public PutObjectRequest() {
     }
 
@@ -282,6 +284,21 @@ public class PutObjectRequest extends PutObjectBasicRequest {
 
     public void setCallback(Callback callback) {
         this.callback = callback;
+    }
+
+    /**
+     * @return Whether you need sdk to calculate CRC64 value and add it to header
+     */
+    public boolean isNeedCalculateCRC64() {
+        return needCalculateCRC64;
+    }
+
+    /**
+     * @param needCalculateCRC64
+     *      Whether you need sdk to calculate CRC64 value and add it to header
+     */
+    public void setNeedCalculateCRC64(boolean needCalculateCRC64) {
+        this.needCalculateCRC64 = needCalculateCRC64;
     }
     @Override
     public String toString() {

--- a/app/src/main/java/com/obs/services/model/S3Object.java
+++ b/app/src/main/java/com/obs/services/model/S3Object.java
@@ -14,6 +14,8 @@
 
 package com.obs.services.model;
 
+import com.obs.services.internal.utils.CRC64InputStream;
+
 import java.io.InputStream;
 
 @Deprecated
@@ -37,6 +39,8 @@ public class S3Object {
     protected ObjectMetadata metadata;
 
     protected InputStream objectContent;
+
+    protected CRC64InputStream objectContentWithCRC64;
 
     public String getBucketName() {
         return bucketName;
@@ -67,6 +71,12 @@ public class S3Object {
 
     public InputStream getObjectContent() {
         return objectContent;
+    }
+    public CRC64InputStream getObjectContentWithCRC64() {
+        if (objectContentWithCRC64 == null) {
+            objectContentWithCRC64 = new CRC64InputStream(objectContent);
+        }
+        return objectContentWithCRC64;
     }
 
     public void setObjectContent(InputStream objectContent) {

--- a/app/src/main/java/com/obs/services/model/UploadFileRequest.java
+++ b/app/src/main/java/com/obs/services/model/UploadFileRequest.java
@@ -45,6 +45,12 @@ public class UploadFileRequest extends PutObjectBasicRequest {
 
     private long progressInterval = ObsConstraint.DEFAULT_PROGRESS_INTERVAL;
 
+    private boolean needAbortUploadFileAfterCancel = false;
+
+    private boolean needCalculateCRC64 = false;
+
+    private boolean needStreamCalculateCRC64 = false;
+
     /**
      * Constructor
      * 
@@ -428,6 +434,44 @@ public class UploadFileRequest extends PutObjectBasicRequest {
         this.callback = callback;
     }
 
+    public boolean isNeedAbortUploadFileAfterCancel() {
+        return needAbortUploadFileAfterCancel;
+    }
+
+    public void setNeedAbortUploadFileAfterCancel(boolean needAbortUploadFileAfterCancel) {
+        this.needAbortUploadFileAfterCancel = needAbortUploadFileAfterCancel;
+    }
+
+    /**
+     * @return Whether you need sdk to calculate CRC64 value and add it to header
+     */
+    public boolean isNeedCalculateCRC64() {
+        return needCalculateCRC64;
+    }
+
+    /**
+     * @param needCalculateCRC64
+     *      Whether you need sdk to calculate CRC64 value and add it to header
+     */
+    public void setNeedCalculateCRC64(boolean needCalculateCRC64) {
+        this.needCalculateCRC64 = needCalculateCRC64;
+    }
+
+
+    /**
+     * @return Whether you need sdk to calculate CRC64 value by stream, priority is lower than needCalculateCRC64
+     */
+    public boolean isNeedStreamCalculateCRC64() {
+        return needStreamCalculateCRC64;
+    }
+
+    /**
+     * @param needStreamCalculateCRC64
+     *      Whether you need sdk to calculate CRC64 value by stream, priority is lower than needCalculateCRC64
+     */
+    public void setNeedStreamCalculateCRC64(boolean needStreamCalculateCRC64) {
+        this.needStreamCalculateCRC64 = needStreamCalculateCRC64;
+    }
     @Override
     public String toString() {
         return "UploadFileRequest [bucketName=" + bucketName + ", objectKey=" + objectKey + ", partSize=" + partSize

--- a/app/src/main/java/com/obs/services/model/UploadPartRequest.java
+++ b/app/src/main/java/com/obs/services/model/UploadPartRequest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.InputStream;
 
 import com.obs.services.internal.ObsConstraint;
+import com.obs.services.internal.ProgressManager;
 
 /**
  * Parameters in a part upload request
@@ -50,6 +51,8 @@ public class UploadPartRequest extends AbstractMultipartRequest {
     private ProgressListener progressListener;
 
     private long progressInterval = ObsConstraint.DEFAULT_PROGRESS_INTERVAL;
+    private boolean needCalculateCRC64 = false;
+    private ProgressManager progressManager;
 
     public UploadPartRequest() {
     }
@@ -369,6 +372,36 @@ public class UploadPartRequest extends AbstractMultipartRequest {
         this.progressInterval = progressInterval;
     }
 
+    /**
+     * @return Whether you need sdk to calculate CRC64 value and add it to header
+     */
+    public boolean isNeedCalculateCRC64() {
+        return needCalculateCRC64;
+    }
+
+    /**
+     * @param needCalculateCRC64
+     *      Whether you need sdk to calculate CRC64 value and add it to header
+     */
+    public void setNeedCalculateCRC64(boolean needCalculateCRC64) {
+        this.needCalculateCRC64 = needCalculateCRC64;
+    }
+
+    /**
+     * @return progressManager
+     *      get progressManager which receives progress, progressManager priority is higher than ProgressListener
+     */
+    public ProgressManager getProgressManager() {
+        return progressManager;
+    }
+
+    /**
+     * @param progressManager
+     *      set progressManager to receive progress, progressManager priority is higher than ProgressListener
+     */
+    public void setProgressManager(ProgressManager progressManager) {
+        this.progressManager = progressManager;
+    }
     @Override
     public String toString() {
         return "UploadPartRequest [uploadId=" + this.getUploadId() + ", bucketName=" + this.getBucketName()

--- a/app/src/main/java/com/obs/services/model/UploadPartResult.java
+++ b/app/src/main/java/com/obs/services/model/UploadPartResult.java
@@ -14,6 +14,8 @@
 
 package com.obs.services.model;
 
+import com.obs.services.internal.utils.CRC64;
+
 /**
  * Response to a part upload request
  */
@@ -21,6 +23,8 @@ public class UploadPartResult extends HeaderResponse {
     private int partNumber;
 
     private String etag;
+
+    private CRC64 clientCalculatedCRC64;
 
     /**
      * Obtain the part number.
@@ -48,8 +52,17 @@ public class UploadPartResult extends HeaderResponse {
         this.etag = objEtag;
     }
 
+
+    public CRC64 getClientCalculatedCRC64() {
+        return clientCalculatedCRC64;
+    }
+
+    public void setClientCalculatedCRC64(CRC64 clientCalculatedCRC64) {
+        this.clientCalculatedCRC64 = clientCalculatedCRC64;
+    }
     @Override
     public String toString() {
-        return "UploadPartResult [partNumber=" + partNumber + ", etag=" + etag + "]";
+        return "UploadPartResult [partNumber=" + partNumber + ", etag=" + etag +
+                ", clientCalculatedCRC64=" + clientCalculatedCRC64 + "]";
     }
 }

--- a/app/src/main/java/com/obs/services/model/fs/NewFileRequest.java
+++ b/app/src/main/java/com/obs/services/model/fs/NewFileRequest.java
@@ -77,4 +77,22 @@ public class NewFileRequest extends PutObjectRequest {
         this.objectKey = objectKey;
     }
 
+
+    /**
+     * @return Whether you need sdk to calculate CRC64 value and check it by adding to header
+     */
+    @Override
+    public boolean isNeedCalculateCRC64() {
+        // not supported in this API
+        return false;
+    }
+
+    /**
+     * @param needCalculateCRC64 Whether you need sdk to calculate CRC64 value and check it by adding to header
+     */
+    @Override
+    public void setNeedCalculateCRC64(boolean needCalculateCRC64) throws IllegalArgumentException {
+        // not supported in this API
+        throw new IllegalArgumentException("not supported in this API");
+    }
 }

--- a/app/src/main/java/com/obs/services/model/fs/WriteFileRequest.java
+++ b/app/src/main/java/com/obs/services/model/fs/WriteFileRequest.java
@@ -109,4 +109,23 @@ public class WriteFileRequest extends AppendObjectRequest {
         this(bucketName, objectKey, input);
         this.position = position;
     }
+
+
+    /**
+     * @return Whether you need sdk to calculate CRC64 value and check it by adding to header
+     */
+    @Override
+    public boolean isNeedCalculateCRC64() {
+        // not supported in this API
+        return false;
+    }
+
+    /**
+     * @param needCalculateCRC64 Whether you need sdk to calculate CRC64 value and check it by adding to header
+     */
+    @Override
+    public void setNeedCalculateCRC64(boolean needCalculateCRC64) throws IllegalArgumentException {
+        // not supported in this API
+        throw new IllegalArgumentException("not supported in this API");
+    }
 }

--- a/pom-android.xml
+++ b/pom-android.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.huaweicloud</groupId>
 	<artifactId>esdk-obs-android</artifactId>
-	<version>3.24.3</version>
+	<version>3.24.8</version>
 	<packaging>jar</packaging>
 
 	<name>OBS SDK for Android</name>
@@ -24,23 +24,23 @@
 		<dependency>
 			<groupId>com.squareup.okio</groupId>
 			<artifactId>okio</artifactId>
-			<version>3.6.0</version>
+			<version>3.8.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.4</version>
 		</dependency>
 
 	</dependencies>

--- a/pom-java-optimization.xml
+++ b/pom-java-optimization.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.huaweicloud</groupId>
     <artifactId>esdk-obs-java-optimised</artifactId>
-    <version>3.24.3</version>
+    <version>3.24.8</version>
     <packaging>jar</packaging>
 
     <name>OBS SDK for Java Optimised</name>
@@ -29,28 +29,28 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
+            <version>2.15.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.15.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.15.2</version>
+            <version>2.15.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.18.0</version>
+            <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.18.0</version>
+            <version>2.20.0</version>
         </dependency>
     </dependencies>
 

--- a/pom-java.xml
+++ b/pom-java.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.huaweicloud</groupId>
     <artifactId>esdk-obs-java</artifactId>
-    <version>3.24.3</version>
+    <version>3.24.8</version>
     <packaging>jar</packaging>
 
     <name>OBS SDK for Java</name>
@@ -23,36 +23,35 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
-            <version>3.6.0</version>
+            <version>3.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
+            <version>2.15.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.15.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.15.2</version>
+            <version>2.15.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.18.0</version>
+            <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.18.0</version>
+            <version>2.20.0</version>
         </dependency>
-
 
 		<dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.huaweicloud</groupId>
     <artifactId>esdk-obs-java</artifactId>
-    <version>3.24.3</version>
+    <version>3.24.8</version>
     <packaging>jar</packaging>
 
     <name>OBS SDK for Java</name>
@@ -23,34 +23,34 @@
 		<dependency>
 			<groupId>com.squareup.okio</groupId>
 			<artifactId>okio</artifactId>
-			<version>3.6.0</version>
+			<version>3.8.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.4</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.18.0</version>
+			<version>2.20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.18.0</version>
+			<version>2.20.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Resolved issues:
1. PutObject、Getobject、GetObjectMetadata、UploadPart、AppendObject、CopyObject、CopyPart、CompeleMultiUploadPart now supports crc64 checksum.
2. UploadFile can be cancelled and aborted now.
3. Allow you set okhttp's EventListenerFactory to profile each stage of a http request，not set by default.
4. Fixed the issue that client encryption is available only in obs protocal and add some check logic when encryption algrithm is null.
5. Optimised the logic of set progress listener when using uploadFile.
6. Optimised some log info format.
7. Added some logic to compatible with Android 7.0 when using DateTimeFormatter.

Third-party dependence:
1. Replace okio 3.8.0 with okio 3.6.0
2. Replace log4j-core 2.20.0 with log4j-core 2.18.0
3. Replace jackson-core 2.15.4 with jackson-core 2.15.2
4. Replace jackson-databind 2.15.4 with jackson-databind 2.15.2
5. Replace jackson-annotations 2.15.4 with jackson-annotations 2.15.2
6. Replace log4j-api 2.20.0 with log4j-api 2.18.0